### PR TITLE
Header wrap fix

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -12,5 +12,7 @@
  *= require_tree .
  */
 
+$grid-float-breakpoint: 1000px;
+
 @import "bootstrap-sprockets";
 @import "bootstrap";

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -4,11 +4,6 @@ $Black: #000000;
 $FooterBackground: #161817;
 $H1_header: 3rem;
 $H3_header: 1.7rem;
-$screen-xs-min: 300px;
-$screen-sm-min: 400px;
-$screen-md-min: 800px;
-$screen-lg-min: 1200px;
-$grid-float-breakpoint: $screen-md-min;
 $bottomHeight: 20rem;
 
 // Header


### PR DESCRIPTION
@Salinn Please review. In order for the overrides to work properly with bootstrap-sass, the values have to be defined before you import bootstrap. That's because of the way it initializes - it uses SASS !default, which means that it will normally set its own value, but won't do that if the value already exists. If you don't define it before the import though, it'll get used by bootstrap-sass before you ever change the value, so it won't work. So the key here is you just need to make sure the order of execution is well defined.

I had trouble getting the gems installed on my machine for some reason, so I haven't actually been able to verify this works correctly. You should definitely give the branch a test drive before merging. Also, I removed the other screen mins you had setup under the assumption you had just been playing with them trying to get this to work - feel free to put those back in place if you actually need them.
